### PR TITLE
fix: yaml safe_load with collection counters

### DIFF
--- a/worlds/luigismansion/LMGenerator.py
+++ b/worlds/luigismansion/LMGenerator.py
@@ -2,6 +2,18 @@ import hashlib
 import os
 import yaml
 
+from collections import Counter
+
+def counter_constructor(loader, node):
+    args = loader.construct_sequence(node)
+    return Counter(*args)
+
+# Core implemented custom collection counters which yaml.safe_load cannot serialize by default.
+yaml.SafeLoader.add_constructor(
+    'tag:yaml.org,2002:python/object/apply:collections.Counter',
+    counter_constructor
+)
+
 from worlds.luigismansion.iso_helper.DOL_Updater import update_dol_offsets
 from .iso_helper.Update_GameUSA import update_game_usa
 from .JMP_Info_File import JMPInfoFile


### PR DESCRIPTION
With [this commit](https://github.com/ArchipelagoMW/Archipelago/commit/05c1751d293ea27fa4ee7c6f4797be772d111ae2), the AP core changed the output object and added collection counters, which are not supported by default by the yaml.safe_load (and safe_dump) modules.
This addresses the shortcoming by adding a constructor for these kinda counters.